### PR TITLE
migrate WebRTC handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,3 +88,134 @@ io.on('connection', (socket: Socket) => {
     }
   });
 })
+
+class VoicePeerMultimap{
+  private multimap:{[idx:string]:Set<string>};
+  constructor(){
+    this.multimap={};
+  }
+  add(idx:string, entry:string){
+    if(!(idx in this.multimap))
+      this.multimap[idx] = new Set<string>();
+    this.multimap[idx].add(entry);
+  }
+  has(idx:string, entry:string){
+    if(!(idx in this.multimap))
+      return false;
+    return this.multimap[idx].has(entry);
+  }
+  delete(idx:string, entry:string){
+    if(!(idx in this.multimap))
+      return false;
+    return this.multimap[idx].delete(entry);
+  }
+  forEach(idx:string, lambda:(val:string)=>void){
+    if(!(idx in this.multimap))
+      return;
+    for(var el of this.multimap[idx]){
+      lambda(el);
+    }
+  }
+  getSet(idx:string){
+    if(!(idx in this.multimap))
+      return new Set<string>();
+    else
+      return new Set<string>(this.multimap[idx]);
+  }
+  getList(idx:string){
+    if(!(idx in this.multimap))
+      return []
+    return [...this.multimap[idx]]
+  }
+}
+const map_d2s:VoicePeerMultimap = new VoicePeerMultimap();
+const map_s2d:VoicePeerMultimap = new VoicePeerMultimap();
+const map_c2s:{[cid:string]:string}={};
+const map_s2n:{[cid:string]:string}={};
+const sockets:{[sid:string]:Socket} = {};
+type RTC_JSON_join = {did:string;cid:string;nick:string};
+type RTC_JSON_whois = {sid:string};
+type RTC_JSON_fwd = {sid:string;[other:string]:any};
+
+io.on('connection', (socket: Socket) => {
+  const sid:SocketID = socket.id;
+  var joined:boolean = false;
+  var did:DocID ='';
+  var cid:ClientID ='';
+
+
+  const register_forward_callback = (cmd:string)=>{
+    socket.on(cmd, (data:RTC_JSON_fwd)=>{
+      const peer_sid:SocketID = data['sid'];
+      if(!map_s2d.has(peer_sid,did))
+        return;
+      data['sid'] = sid;
+      sockets[peer_sid].emit(cmd,data);
+    })
+  }
+  const on_peer_quit = ()=>{
+    if(!joined)
+      return;
+    
+      map_d2s.delete(did,sid);
+      map_s2d.delete(sid,did);
+      if(sid==map_c2s[cid])
+        delete map_c2s[cid];
+      joined=false;
+      
+      map_d2s.forEach(did,(peer_sid:SocketID)=>{
+        sockets[peer_sid].emit("peer del",sid);
+      });
+      console.log(`vc quit: peer ${sid} / doc ${did}`)
+      delete sockets[sid];
+      delete map_s2n[sid];
+  }
+
+  register_forward_callback('rtc offer');
+  register_forward_callback('rtc answer');
+  register_forward_callback('rtc iceCandidate');
+
+  socket.on('peer list',()=>{
+    
+    socket.emit("result peer list", map_d2s.getList(did));
+  });
+  socket.on('peer join',(data:RTC_JSON_join)=>{
+    if(joined)
+      return;
+    
+    sockets[sid] = socket;
+    did = data['did'];
+    cid = data['cid'];
+    const nick = data['nick'];
+    var peers = map_d2s.getSet(did);
+    if((cid in map_c2s) && (map_c2s[cid] in sockets)){
+      var prev_sid:SocketID = map_c2s[cid];
+      map_d2s.forEach(did,(peer_sid:SocketID)=>{
+        sockets[peer_sid].emit("peer kick",prev_sid);
+        peers.delete(prev_sid);
+      })
+    }
+    map_d2s.forEach(did,(peer_sid:SocketID)=>{
+      sockets[peer_sid].emit("peer new",sid);
+    })
+    map_d2s.add(did,sid);
+    map_s2d.add(sid,did);
+
+    map_c2s[cid]=sid;
+    map_s2n[sid]=nick;
+    joined=true;
+    peers.add(sid);
+
+    socket.emit("result peer join", {me:sid,list:[...peers]});
+    console.log(`vc join: peer ${sid} / nick ${nick} / doc ${did}`)
+  });
+  socket.on('peer whois',(data:RTC_JSON_whois)=>{
+    if(!joined)
+      return;
+    const query_sid:string = data['sid'];
+    var query_nick:string = map_s2n[query_sid];
+    socket.emit("result peer whois", {sid:query_sid,nick:query_nick})
+  })
+  socket.on('peer quit',on_peer_quit);
+  socket.on('disconnect',on_peer_quit);
+})


### PR DESCRIPTION
기존 채팅쪽이랑 코드가 겹치는 부분이 있어보이지만 일단 따로 작성했습니다.
처음엔 일방적으로 정보를 보내는 것 위주에, 예외적으로 응답이 필요한 것이 있어서 ``socketio``만 사용했는데,
제대로 형태를 갖춘 API를 구현하면 코드가 더 이뻐질듯요.

이곳에서 접속중인 유저의 상태를 상당히 자세히 다루고 있는데,
닉네임 관련 처리를 여기 서버로 뺄수도 있어보이네요.